### PR TITLE
Fix GitHub typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
 
       <h1>Cohorts by Keen IO</h1>
       <p class="lead">Quickly build and visualize beautiful cohort analyses</p>
-      <a class="btn hero-btn" href="https://github.com/keen/cohorts" target="_blank">Source Code on Github</a>
+      <a class="btn hero-btn" href="https://github.com/keen/cohorts" target="_blank">Source Code on GitHub</a>
 
       <iframe src="http://ghbtns.com/github-btn.html?user=keen&amp;repo=cohorts&amp;type=watch&amp;count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>


### PR DESCRIPTION
GitHub should have a capitalized "H" in it :)